### PR TITLE
sync-mvp-api: switch persistence from JSON file to SQLite DB

### DIFF
--- a/docs/sync_mvp_api_operations_checklist.md
+++ b/docs/sync_mvp_api_operations_checklist.md
@@ -23,6 +23,20 @@ curl -sS http://127.0.0.1:8088/healthz
 
 期待値:
 - `{"ok":true,...}` が返る
+- `db_path` が期待する SQLite ファイルを指す
+
+### 2.1 JSON -> DB 初回移行の確認
+
+前提: `.env` に `TSUPASSWD_SYNC_DB_PATH` と `TSUPASSWD_SYNC_STORE_PATH` を設定済み。
+
+```bash
+sudo systemctl restart sync-mvp-api
+curl -sS http://127.0.0.1:8088/healthz
+```
+
+確認ポイント:
+- `db_path` が想定パスである
+- その後の 403/200/409 スモーク（本チェックリストの「3」）が成功する
 
 ## 3. API スモークテスト（403 / 200 / 409）
 

--- a/sync-mvp-api/Program.cs
+++ b/sync-mvp-api/Program.cs
@@ -1,6 +1,6 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Data.Sqlite;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,15 +14,21 @@ var app = builder.Build();
 var requiredToken = Environment.GetEnvironmentVariable("TSUPASSWD_SYNC_BEARER_TOKEN")
     ?? Environment.GetEnvironmentVariable("TSUPASSWD_SYNC_DEV_BEARER_TOKEN")
     ?? "dev-token";
-var storePath = Environment.GetEnvironmentVariable("TSUPASSWD_SYNC_STORE_PATH")
+var dbPath = Environment.GetEnvironmentVariable("TSUPASSWD_SYNC_DB_PATH")
+    ?? Path.Combine(AppContext.BaseDirectory, "vault-store.db");
+var legacyJsonStorePath = Environment.GetEnvironmentVariable("TSUPASSWD_SYNC_STORE_PATH")
     ?? Path.Combine(AppContext.BaseDirectory, "vault-store.json");
 
-var store = new ConcurrentDictionary<string, VaultDocument>(StringComparer.Ordinal);
-var persistLock = new object();
+EnsureDbSchema(dbPath);
+TryMigrateJsonStoreToDb(legacyJsonStorePath, dbPath);
 
-LoadStoreFromDisk(store, storePath);
-
-app.MapGet("/healthz", () => Results.Ok(new { ok = true, service = "sync-mvp-api", store_path = storePath }));
+app.MapGet("/healthz", () => Results.Ok(new
+{
+    ok = true,
+    service = "sync-mvp-api",
+    db_path = dbPath,
+    legacy_json_store_path = legacyJsonStorePath
+}));
 
 app.MapGet("/v1/vaults/{userId}", (HttpContext http, string userId) =>
 {
@@ -32,7 +38,7 @@ app.MapGet("/v1/vaults/{userId}", (HttpContext http, string userId) =>
         return auth;
     }
 
-    if (!store.TryGetValue(userId, out var doc))
+    if (!TryGetVaultFromDb(dbPath, userId, out var doc) || doc is null)
     {
         return Results.NotFound(new ErrorResponse("VAULT_NOT_FOUND", "vault not found"));
     }
@@ -59,7 +65,7 @@ app.MapPut("/v1/vaults/{userId}", async (HttpContext http, string userId) =>
         return Results.BadRequest(new ErrorResponse("INVALID_VERSION", "new_version must be > 0"));
     }
 
-    var existing = store.TryGetValue(userId, out var current) ? current : null;
+    var existing = TryGetVaultFromDb(dbPath, userId, out var current) ? current : null;
     var currentVersion = existing?.VaultVersion ?? 0;
 
     if (request.ExpectedVersion != currentVersion)
@@ -89,8 +95,14 @@ app.MapPut("/v1/vaults/{userId}", async (HttpContext http, string userId) =>
         }
     };
 
-    store[userId] = next;
-    SaveStoreToDisk(store, storePath, persistLock);
+    if (!TryWriteVaultWithVersionCheck(dbPath, userId, request.ExpectedVersion, next, out var serverVersion))
+    {
+        return Results.Conflict(new
+        {
+            code = "VERSION_CONFLICT",
+            server_version = serverVersion
+        });
+    }
 
     return Results.Ok(new
     {
@@ -102,18 +114,40 @@ app.MapPut("/v1/vaults/{userId}", async (HttpContext http, string userId) =>
 
 app.Run("http://127.0.0.1:8088");
 
-static void LoadStoreFromDisk(ConcurrentDictionary<string, VaultDocument> store, string storePath)
+static void EnsureDbSchema(string dbPath)
 {
-    if (!File.Exists(storePath))
+    var parentDir = Path.GetDirectoryName(dbPath);
+    if (!string.IsNullOrWhiteSpace(parentDir))
+    {
+        Directory.CreateDirectory(parentDir);
+    }
+
+    using var connection = CreateConnection(dbPath);
+    connection.Open();
+
+    using var command = connection.CreateCommand();
+    command.CommandText = @"
+CREATE TABLE IF NOT EXISTS vaults (
+    user_id TEXT PRIMARY KEY,
+    vault_version INTEGER NOT NULL,
+    document_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);";
+    command.ExecuteNonQuery();
+}
+
+static void TryMigrateJsonStoreToDb(string legacyJsonStorePath, string dbPath)
+{
+    if (!File.Exists(legacyJsonStorePath) || GetVaultCount(dbPath) > 0)
     {
         return;
     }
 
     try
     {
-        var json = File.ReadAllText(storePath);
+        var json = File.ReadAllText(legacyJsonStorePath);
         var persisted = JsonSerializer.Deserialize<PersistedStore>(json);
-        if (persisted?.Vaults is null)
+        if (persisted?.Vaults is null || persisted.Vaults.Count == 0)
         {
             return;
         }
@@ -122,42 +156,112 @@ static void LoadStoreFromDisk(ConcurrentDictionary<string, VaultDocument> store,
         {
             if (!string.IsNullOrWhiteSpace(kv.Key) && kv.Value is not null)
             {
-                store[kv.Key] = kv.Value;
+                UpsertVaultToDb(dbPath, kv.Key, kv.Value);
             }
         }
     }
     catch
     {
-        // MVP: 壊れたファイルは無視して空ストアで起動する。
+        // MVP: 壊れた JSON は無視して空 DB で起動する。
     }
 }
 
-static void SaveStoreToDisk(ConcurrentDictionary<string, VaultDocument> store, string storePath, object persistLock)
+static bool TryGetVaultFromDb(string dbPath, string userId, out VaultDocument? document)
 {
-    lock (persistLock)
+    document = null;
+
+    using var connection = CreateConnection(dbPath);
+    connection.Open();
+
+    using var command = connection.CreateCommand();
+    command.CommandText = "SELECT document_json FROM vaults WHERE user_id = $userId;";
+    command.Parameters.AddWithValue("$userId", userId);
+
+    var json = command.ExecuteScalar() as string;
+    if (string.IsNullOrWhiteSpace(json))
     {
-        var parentDir = Path.GetDirectoryName(storePath);
-        if (!string.IsNullOrWhiteSpace(parentDir))
-        {
-            Directory.CreateDirectory(parentDir);
-        }
-
-        var snapshot = new PersistedStore
-        {
-            Vaults = store.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal)
-        };
-
-        var options = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
-        var json = JsonSerializer.Serialize(snapshot, options);
-        var tempPath = storePath + ".tmp";
-        File.WriteAllText(tempPath, json);
-        File.Move(tempPath, storePath, true);
+        return false;
     }
+
+    document = JsonSerializer.Deserialize<VaultDocument>(json);
+    return document is not null;
+}
+
+static bool TryWriteVaultWithVersionCheck(string dbPath, string userId, long expectedVersion, VaultDocument next, out long serverVersion)
+{
+    serverVersion = 0;
+
+    using var connection = CreateConnection(dbPath);
+    connection.Open();
+
+    using var transaction = connection.BeginTransaction();
+
+    using (var select = connection.CreateCommand())
+    {
+        select.Transaction = transaction;
+        select.CommandText = "SELECT vault_version FROM vaults WHERE user_id = $userId;";
+        select.Parameters.AddWithValue("$userId", userId);
+        var rawVersion = select.ExecuteScalar();
+        serverVersion = rawVersion is null || rawVersion is DBNull ? 0 : Convert.ToInt64(rawVersion);
+    }
+
+    if (expectedVersion != serverVersion)
+    {
+        transaction.Rollback();
+        return false;
+    }
+
+    UpsertVaultToDbWithConnection(connection, transaction, userId, next);
+    transaction.Commit();
+    return true;
+}
+
+static void UpsertVaultToDb(string dbPath, string userId, VaultDocument document)
+{
+    using var connection = CreateConnection(dbPath);
+    connection.Open();
+    UpsertVaultToDbWithConnection(connection, null, userId, document);
+}
+
+static void UpsertVaultToDbWithConnection(SqliteConnection connection, SqliteTransaction? transaction, string userId, VaultDocument document)
+{
+    using var command = connection.CreateCommand();
+    command.Transaction = transaction;
+    command.CommandText = @"
+INSERT INTO vaults (user_id, vault_version, document_json, updated_at)
+VALUES ($userId, $vaultVersion, $documentJson, $updatedAt)
+ON CONFLICT(user_id) DO UPDATE SET
+    vault_version = excluded.vault_version,
+    document_json = excluded.document_json,
+    updated_at = excluded.updated_at;";
+
+    command.Parameters.AddWithValue("$userId", userId);
+    command.Parameters.AddWithValue("$vaultVersion", document.VaultVersion);
+    command.Parameters.AddWithValue("$documentJson", JsonSerializer.Serialize(document));
+    command.Parameters.AddWithValue("$updatedAt", document.Meta.UpdatedAt.ToString("O"));
+    command.ExecuteNonQuery();
+}
+
+static long GetVaultCount(string dbPath)
+{
+    using var connection = CreateConnection(dbPath);
+    connection.Open();
+
+    using var command = connection.CreateCommand();
+    command.CommandText = "SELECT COUNT(*) FROM vaults;";
+    return Convert.ToInt64(command.ExecuteScalar());
+}
+
+static SqliteConnection CreateConnection(string dbPath)
+{
+    var builder = new SqliteConnectionStringBuilder
+    {
+        DataSource = dbPath,
+        Mode = SqliteOpenMode.ReadWriteCreate,
+        Cache = SqliteCacheMode.Default
+    };
+
+    return new SqliteConnection(builder.ConnectionString);
 }
 
 static IResult? Authorize(HttpContext http, string requiredToken)

--- a/sync-mvp-api/README.md
+++ b/sync-mvp-api/README.md
@@ -12,7 +12,10 @@ PasskeyManager の `SyncClient` から呼ばれる最小 API です。
 # 1) API 側トークン（未設定なら dev-token）
 $env:TSUPASSWD_SYNC_DEV_BEARER_TOKEN = "dev-token"
 
-# 1.5) 保存ファイル（未設定なら 実行フォルダ\vault-store.json）
+# 1.5) DB保存先（未設定なら 実行フォルダ\vault-store.db）
+$env:TSUPASSWD_SYNC_DB_PATH = "c:\\AppPackages\\PasskeyManager\\sync-mvp-api\\data\\vault-store.db"
+
+# 1.6) 旧JSON保存先（初回移行元。未設定なら 実行フォルダ\vault-store.json）
 $env:TSUPASSWD_SYNC_STORE_PATH = "c:\\AppPackages\\PasskeyManager\\sync-mvp-api\\data\\vault-store.json"
 
 # 2) 起動
@@ -25,6 +28,11 @@ dotnet run
 1. `TSUPASSWD_SYNC_BEARER_TOKEN`
 2. `TSUPASSWD_SYNC_DEV_BEARER_TOKEN`
 3. 未設定時は `dev-token`
+
+永続化関連の環境変数:
+
+1. `TSUPASSWD_SYNC_DB_PATH`（保存先SQLite DB）
+2. `TSUPASSWD_SYNC_STORE_PATH`（旧JSON。DB空時の初回移行元）
 
 起動URL:
 - `http://127.0.0.1:8088`
@@ -110,6 +118,19 @@ Invoke-WebRequest -Method Put -Uri "http://127.0.0.1:8088/v1/vaults/ContosoUserI
 
 ## 備考
 
-- このMVPは PUT 後に JSON ファイルへ永続化します（再起動後も復元）。
-- 保存先は `TSUPASSWD_SYNC_STORE_PATH` で変更できます。
+- このMVPは PUT 後に SQLite DB へ永続化します（再起動後も復元）。
+- 保存先は `TSUPASSWD_SYNC_DB_PATH` で変更できます。
+- DB が空で旧JSONファイルが存在する場合、起動時に JSON から DB へ一度だけ移行します。
 - 本番化時は DB 永続化・TLS・監査ログ・レート制限を追加してください。
+
+## JSON -> DB 移行（運用手順）
+
+1. サービス停止
+2. `.env` に `TSUPASSWD_SYNC_DB_PATH` と `TSUPASSWD_SYNC_STORE_PATH` を設定
+3. サービス起動（初回起動で DB が空なら自動移行）
+4. smoke test（403/200/409）で動作確認
+
+```bash
+sudo systemctl restart sync-mvp-api
+curl -sS http://127.0.0.1:8088/healthz
+```

--- a/sync-mvp-api/SyncMvpApi.csproj
+++ b/sync-mvp-api/SyncMvpApi.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- move `sync-mvp-api` persistence from JSON file to SQLite DB
- keep API contract unchanged for `GET /v1/vaults/{userId}` and `PUT /v1/vaults/{userId}`
- preserve version-conflict behavior (`409 VERSION_CONFLICT`) using DB transaction + version check
- add one-time startup migration from legacy JSON store when DB is empty
- expose `db_path` and `legacy_json_store_path` in `/healthz`
- document DB env vars and JSON->DB migration runbook

## Changed Files
- `sync-mvp-api/Program.cs`
- `sync-mvp-api/SyncMvpApi.csproj`
- `sync-mvp-api/README.md`
- `docs/sync_mvp_api_operations_checklist.md`

## Verification
- `dotnet build` succeeded at `sync-mvp-api`
- smoke flow compatibility intended to remain: 403 / 200 / 409

Closes #1